### PR TITLE
fix: permissions for crashpad releases

### DIFF
--- a/.github/workflows/crashpad.yml
+++ b/.github/workflows/crashpad.yml
@@ -188,6 +188,8 @@ jobs:
   create-release:
     needs: build-crashpad
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # Release on every successful build
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
### Description

Required according to the docs: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

and also looks like the repo settings confirm:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2c4cbe16-cb54-40f7-be9a-7ffd9ffcf057" />


### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
