### PR TITLE
feat: wer example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ if(WIN32)
         ${CRASHPAD_OUT_DIR}/obj/util/util.lib
         ${CRASHPAD_OUT_DIR}/obj/third_party/mini_chromium/mini_chromium/base/base.lib
     )
+    # Add WER-specific libraries for Windows
+    set(CRASHPAD_WER_LIBRARIES
+        ${CRASHPAD_OUT_DIR}/obj/handler/win/wer/crashpad_wer.lib
+        wer.lib
+    )
     set(CRASHPAD_HANDLER ${CRASHPAD_OUT_DIR}/crashpad_handler.exe)
 elseif(APPLE)
     set(CRASHPAD_LIBRARIES
@@ -120,6 +125,17 @@ else() # Linux
         OUTPUT_NAME "crash" 
         VERSION 2.0.0 
         SOVERSION 2)
+endif()
+
+# Build the WER callback DLL (Windows only)
+if(WIN32)
+    add_library(wer SHARED wer.cpp wer.h wer.def)
+    set_target_properties(wer PROPERTIES 
+        OUTPUT_NAME "wer"
+        LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/wer.def"
+    )
+    target_link_libraries(wer ${CRASHPAD_WER_LIBRARIES})
+    target_compile_definitions(wer PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 
 # Add executable
@@ -176,6 +192,12 @@ if(WIN32)
         $<TARGET_FILE:crash>
         ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/$<TARGET_FILE_NAME:crash>
     )
+    # Copy the WER callback DLL to the build directory
+    add_custom_command(TARGET wer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE:wer>
+        ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/$<TARGET_FILE_NAME:wer>
+    )
 elseif(APPLE)
     add_custom_command(TARGET crash POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
@@ -224,6 +246,9 @@ endif()
 # Install targets
 install(TARGETS MyCMakeCrasher DESTINATION bin)
 install(TARGETS crash DESTINATION bin)
+if(WIN32)
+    install(TARGETS wer DESTINATION bin)
+endif()
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/crashpad_handler${CMAKE_EXECUTABLE_SUFFIX} DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/attachment.txt DESTINATION bin)
 
@@ -232,7 +257,7 @@ if(WIN32)
   add_custom_target(upload_symbols ALL
     COMMAND powershell -ExecutionPolicy Bypass -File 
             ${CMAKE_CURRENT_SOURCE_DIR}/scripts/upload_symbols.ps1
-    DEPENDS MyCMakeCrasher crash
+    DEPENDS MyCMakeCrasher crash wer
     COMMENT "Uploading symbols to BugSplat"
   )
 elseif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,13 +129,13 @@ endif()
 
 # Build the WER callback DLL (Windows only)
 if(WIN32)
-    add_library(wer SHARED wer.cpp wer.h wer.def)
-    set_target_properties(wer PROPERTIES 
+    add_library(werCallback SHARED wer.cpp wer.h wer.def)
+    set_target_properties(werCallback PROPERTIES 
         OUTPUT_NAME "wer"
         LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/wer.def"
     )
-    target_link_libraries(wer ${CRASHPAD_WER_LIBRARIES})
-    target_compile_definitions(wer PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+    target_link_libraries(werCallback ${CRASHPAD_WER_LIBRARIES})
+    target_compile_definitions(werCallback PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 
 # Add executable
@@ -193,10 +193,10 @@ if(WIN32)
         ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/$<TARGET_FILE_NAME:crash>
     )
     # Copy the WER callback DLL to the build directory
-    add_custom_command(TARGET wer POST_BUILD
+    add_custom_command(TARGET werCallback POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:wer>
-        ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/$<TARGET_FILE_NAME:wer>
+        $<TARGET_FILE:werCallback>
+        ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/$<TARGET_FILE_NAME:werCallback>
     )
 elseif(APPLE)
     add_custom_command(TARGET crash POST_BUILD
@@ -247,7 +247,7 @@ endif()
 install(TARGETS MyCMakeCrasher DESTINATION bin)
 install(TARGETS crash DESTINATION bin)
 if(WIN32)
-    install(TARGETS wer DESTINATION bin)
+    install(TARGETS werCallback DESTINATION bin)
 endif()
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/crashpad_handler${CMAKE_EXECUTABLE_SUFFIX} DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_CONFIG_DIR}/attachment.txt DESTINATION bin)
@@ -257,7 +257,7 @@ if(WIN32)
   add_custom_target(upload_symbols ALL
     COMMAND powershell -ExecutionPolicy Bypass -File 
             ${CMAKE_CURRENT_SOURCE_DIR}/scripts/upload_symbols.ps1
-    DEPENDS MyCMakeCrasher crash wer
+    DEPENDS MyCMakeCrasher crash werCallback
     COMMENT "Uploading symbols to BugSplat"
   )
 elseif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,11 +87,6 @@ if(WIN32)
         ${CRASHPAD_OUT_DIR}/obj/util/util.lib
         ${CRASHPAD_OUT_DIR}/obj/third_party/mini_chromium/mini_chromium/base/base.lib
     )
-    # Add WER-specific libraries for Windows
-    set(CRASHPAD_WER_LIBRARIES
-        ${CRASHPAD_OUT_DIR}/obj/handler/win/wer/crashpad_wer.lib
-        wer.lib
-    )
     set(CRASHPAD_HANDLER ${CRASHPAD_OUT_DIR}/crashpad_handler.exe)
 elseif(APPLE)
     set(CRASHPAD_LIBRARIES
@@ -134,7 +129,8 @@ if(WIN32)
         OUTPUT_NAME "wer"
         LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/wer.def"
     )
-    target_link_libraries(werCallback ${CRASHPAD_WER_LIBRARIES})
+    # Only link with standard Windows libraries - no Crashpad dependencies needed
+    target_link_libraries(werCallback wer.lib)
     target_compile_definitions(werCallback PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,13 @@ if(WIN32)
         OUTPUT_NAME "wer"
         LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/wer.def"
     )
-    # Only link with standard Windows libraries - no Crashpad dependencies needed
-    target_link_libraries(werCallback wer.lib)
+    # Link with Crashpad libraries that contain WER functionality
+    target_link_libraries(werCallback 
+        ${CRASHPAD_OUT_DIR}/obj/handler/handler.lib
+        ${CRASHPAD_OUT_DIR}/obj/util/util.lib
+        ${CRASHPAD_OUT_DIR}/obj/third_party/mini_chromium/mini_chromium/base/base.lib
+        wer.lib
+    )
     target_compile_definitions(werCallback PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
 endif()
 

--- a/WER_INTEGRATION.md
+++ b/WER_INTEGRATION.md
@@ -1,0 +1,123 @@
+# Windows Error Reporting (WER) Integration
+
+This document explains the WER callback integration that has been added to catch crashes that Crashpad might miss.
+
+## Overview
+
+Windows Error Reporting (WER) can catch certain types of crashes that Crashpad's in-process handlers might miss, particularly:
+
+- **Stack Overflow** (`STATUS_STACK_OVERFLOW`, `STATUS_STACK_BUFFER_OVERRUN`)
+- **Heap Corruption** (`STATUS_HEAP_CORRUPTION`)
+- **Severe Access Violations** (in certain contexts)
+
+This implementation follows Chrome's approach by creating a separate WER callback DLL that registers with Windows to handle these exception types.
+
+## Architecture
+
+### Components Created
+
+1. **`wer.cpp`** - WER callback DLL implementation
+2. **`wer.h`** - Header for WER callback exports
+3. **`wer.def`** - Module definition file for DLL exports
+4. **WER Registration Functions** - In `main.cpp` for registering/unregistering callbacks
+
+### How It Works
+
+1. **Application Startup**: Main application registers the WER callback DLL
+2. **Crash Occurs**: If Crashpad can't handle the crash, WER takes over
+3. **WER Callback**: Our DLL receives the exception information
+4. **Crashpad Processing**: Uses `crashpad::wer::ExceptionEvent` to process the crash
+5. **Report Upload**: Crash gets uploaded to BugSplat through Crashpad's infrastructure
+
+## Exception Types Handled
+
+```cpp
+DWORD wanted_exceptions[] = {
+    0xC0000409,  // STATUS_STACK_BUFFER_OVERRUN (stack overflow/corruption)
+    0xC00000FD,  // STATUS_STACK_OVERFLOW (stack overflow)
+    0xC0000374,  // STATUS_HEAP_CORRUPTION (heap corruption)
+    0xC0000005,  // STATUS_ACCESS_VIOLATION (in specific contexts)
+};
+```
+
+## Testing Different Crash Types
+
+In `main.cpp`, function `func2()` contains crash type selection:
+
+```cpp
+// 1. NULL POINTER DEREFERENCE (Crashpad handles this well)
+// crash_func_t crash_func = loadCrashFunction("crash");
+
+// 2. STACK OVERFLOW (WER catches this better) - CURRENTLY SELECTED
+crash_func_t crash_func = loadCrashFunction("crashStackOverflow");
+
+// 3. ACCESS VIOLATION (Both can catch, WER might provide better details)
+// crash_func_t crash_func = loadCrashFunction("crashAccessViolation");
+
+// 4. HEAP CORRUPTION (WER often catches these better)
+// crash_func_t crash_func = loadCrashFunction("crashHeapCorruption");
+```
+
+## Build Process (Windows Only)
+
+The CMakeLists.txt has been updated to:
+
+1. **Build WER DLL**: Creates `wer.dll`
+2. **Link WER Libraries**: Links against `crashpad_wer.lib` and `wer.lib`
+3. **Copy to Output**: Copies DLL to build directory
+4. **Symbol Upload**: Includes WER DLL in symbol uploads
+
+## Runtime Behavior
+
+### Success Case
+```
+Hello, World!
+Crashpad initialized successfully!
+Successfully registered WER callback: C:\path\to\wer.dll
+WER callbacks registered for enhanced crash detection!
+Generating crash...
+[Application crashes - WER callback processes it through Crashpad]
+```
+
+### Failure Case
+```
+Hello, World!
+Crashpad initialized successfully!
+Warning: Failed to register WER callbacks. Some crash types may not be reported.
+```
+
+## Platform Behavior
+
+- **Windows**: Full WER integration with callback DLL
+- **macOS/Linux**: Standard Crashpad behavior (WER code is conditionally compiled out)
+
+## Benefits
+
+✅ **Enhanced Coverage**: Catches crashes that Crashpad alone might miss  
+✅ **Unified Reporting**: All crashes still go through Crashpad → BugSplat  
+✅ **Chrome-Tested**: Uses the same approach as Chrome's crash reporting  
+✅ **Graceful Fallback**: Application continues if WER registration fails  
+
+## Debugging
+
+To verify WER integration:
+
+1. **Check Registration**: Look for "Successfully registered WER callback" message
+2. **Test Stack Overflow**: Use `crashStackOverflow()` function
+3. **Event Viewer**: Check Windows Event Viewer for WER events
+4. **BugSplat Dashboard**: Verify crash reports appear in BugSplat
+
+## Files Modified/Added
+
+### New Files
+- `wer.cpp` - WER callback implementation
+- `wer.h` - WER callback header
+- `wer.def` - DLL export definitions
+
+### Modified Files
+- `CMakeLists.txt` - Added WER DLL build target
+- `main.cpp` - Added WER registration functions and calls
+- `main.h` - Added WER function declarations
+- `crash.cpp` - Added multiple crash type functions
+
+This implementation provides comprehensive crash coverage by combining Crashpad's cross-platform capabilities with Windows-specific WER integration for maximum crash detection coverage.

--- a/crash.cpp
+++ b/crash.cpp
@@ -1,7 +1,6 @@
 #include <cstddef>
 
 extern "C" {
-    // Function that will cause a crash
     #ifdef _WIN32
     __declspec(dllexport)
     #else
@@ -10,5 +9,44 @@ extern "C" {
     void crash() {
         // Dereference null pointer to cause a crash
         *(volatile int*)nullptr = 42;
+    }
+
+    #ifdef _WIN32
+    __declspec(dllexport)
+    #else
+    __attribute__((visibility("default")))
+    #endif
+    void crashStackOverflow() {
+        // Recursive function that will cause stack overflow
+        // Use volatile to prevent compiler optimization
+        volatile char buffer[8192];  // Large stack allocation
+        buffer[0] = 1;  // Touch the memory to ensure allocation
+        
+        // Infinite recursion to overflow the stack
+        crashStackOverflow();
+    }
+
+    #ifdef _WIN32
+    __declspec(dllexport)
+    #else
+    __attribute__((visibility("default")))
+    #endif
+    void crashAccessViolation() {
+        // Try to write to an invalid memory address
+        volatile int* invalid_ptr = (volatile int*)0xDEADBEEF;
+        *invalid_ptr = 42;
+    }
+
+    #ifdef _WIN32
+    __declspec(dllexport)
+    #else
+    __attribute__((visibility("default")))
+    #endif
+    void crashHeapCorruption() {
+        // Allocate memory and then corrupt it
+        int* ptr = new int[10];
+        delete[] ptr;
+        // Use after free - this can cause heap corruption
+        *ptr = 42;
     }
 } 

--- a/main.cpp
+++ b/main.cpp
@@ -31,30 +31,17 @@ using namespace std;
 
 int main()
 {
-    // Initialize Crashpad crash reporting
+    // Initialize Crashpad crash reporting (including WER registration on Windows)
     if (!initializeCrashpad(BUGSPLAT_DATABASE, BUGSPLAT_APP_NAME, BUGSPLAT_APP_VERSION))
     {
         std::cerr << "Failed to initialize Crashpad" << std::endl;
         return 1;
     }
-    
-#ifdef _WIN32
-    // Register WER callbacks on Windows to catch exceptions Crashpad might miss
-    if (!registerWERCallbacks()) {
-        std::cout << "Warning: Failed to register WER callbacks. " 
-                  << "Some crash types may not be reported." << std::endl;
-    }
-    
-    // Set up cleanup for WER callbacks
-    std::atexit([]() {
-        unregisterWERCallbacks();
-    });
-#endif
 
     std::cout << "Hello, World!" << std::endl;
     std::cout << "Crashpad initialized successfully!" << std::endl;
 #ifdef _WIN32
-    std::cout << "WER callbacks registered for enhanced crash detection!" << std::endl;
+    std::cout << "WER integration enabled for enhanced crash detection!" << std::endl;
 #endif
     std::cout << "Generating crash..." << std::endl;
 
@@ -151,62 +138,25 @@ bool initializeCrashpad(std::string dbName, std::string appName, std::string app
         attachments // Add attachment
     );
 
+#ifdef _WIN32
+    // Register WER module after starting the handler
+    if (success) {
+        std::string werDllPath = exeDir + "/wer.dll";
+        if (std::filesystem::exists(werDllPath)) {
+            std::wstring werDllPathW(werDllPath.begin(), werDllPath.end());
+            if (client.RegisterWerModule(werDllPathW)) {
+                std::cout << "Successfully registered WER module: " << werDllPath << std::endl;
+            } else {
+                std::cerr << "Failed to register WER module: " << werDllPath << std::endl;
+            }
+        }
+    }
+#endif
+
     return success;
 }
 
-#ifdef _WIN32
-// Function to register WER callbacks on Windows
-bool registerWERCallbacks() {
-    std::string exeDir = getExecutableDir();
-    std::string werCallbackPath = exeDir + "/wer.dll";
-    
-    // Check if WER callback DLL exists
-    if (!std::filesystem::exists(werCallbackPath)) {
-        std::cerr << "WER callback DLL not found at: " << werCallbackPath << std::endl;
-        return false;
-    }
-    
-    // Convert to wide string for Windows API
-    std::wstring werCallbackPathW(werCallbackPath.begin(), werCallbackPath.end());
-    
-    // Register the WER callback module
-    HRESULT hr = WerRegisterRuntimeExceptionModule(
-        werCallbackPathW.c_str(),  // Path to our WER callback DLL
-        nullptr                    // Context pointer (not used)
-    );
-    
-    if (SUCCEEDED(hr)) {
-        std::cout << "Successfully registered WER callback: " << werCallbackPath << std::endl;
-        return true;
-    } else {
-        std::cerr << "Failed to register WER callback. HRESULT: 0x" 
-                  << std::hex << hr << std::dec << std::endl;
-        return false;
-    }
-}
 
-// Function to unregister WER callbacks on Windows
-void unregisterWERCallbacks() {
-    std::string exeDir = getExecutableDir();
-    std::string werCallbackPath = exeDir + "/wer.dll";
-    
-    // Convert to wide string for Windows API
-    std::wstring werCallbackPathW(werCallbackPath.begin(), werCallbackPath.end());
-    
-    // Unregister the WER callback module
-    HRESULT hr = WerUnregisterRuntimeExceptionModule(
-        werCallbackPathW.c_str(),  // Path to our WER callback DLL
-        nullptr                    // Context pointer (not used)
-    );
-    
-    if (SUCCEEDED(hr)) {
-        std::cout << "Successfully unregistered WER callback" << std::endl;
-    } else {
-        std::cerr << "Failed to unregister WER callback. HRESULT: 0x" 
-                  << std::hex << hr << std::dec << std::endl;
-    }
-}
-#endif
 
 // Struct to manage library handle and provide RAII cleanup
 struct LibraryHandle

--- a/main.cpp
+++ b/main.cpp
@@ -28,50 +28,28 @@
 using namespace crashpad;
 using namespace std;
 
-// Function to get the executable directory
-std::string getExecutableDir() {
-#ifdef _WIN32
-    char path[MAX_PATH];
-    GetModuleFileNameA(NULL, path, MAX_PATH);
-    std::string pathStr(path);
-    size_t lastBackslash = pathStr.find_last_of('\\');
-    if (lastBackslash != std::string::npos) {
-        return pathStr.substr(0, lastBackslash);
-    }
-    return "";
-#elif defined(__APPLE__)
-    char path[PATH_MAX];
-    uint32_t size = sizeof(path);
-    if (_NSGetExecutablePath(path, &size) == 0) {
-        std::string pathStr(path);
-        size_t lastSlash = pathStr.find_last_of('/');
-        if (lastSlash != std::string::npos) {
-            return pathStr.substr(0, lastSlash);
-        }
-    }
-    return "";
-#else // Linux
-    char pBuf[FILENAME_MAX];
-    int len = sizeof(pBuf);
-    int bytes = MIN(readlink("/proc/self/exe", pBuf, len), len - 1);
-    if (bytes >= 0) {
-        pBuf[bytes] = '\0';
+int main()
+{
+    if (!initializeCrashpad(BUGSPLAT_DATABASE, BUGSPLAT_APP_NAME, BUGSPLAT_APP_VERSION))
+    {
+        std::cerr << "Failed to initialize Crashpad" << std::endl;
+        return 1;
     }
 
-    char *lastForwardSlash = strrchr(&pBuf[0], '/');
-    if (lastForwardSlash == NULL)
-        return "";
-    *lastForwardSlash = '\0';
+    std::cout << "Hello, World!" << std::endl;
+    std::cout << "Crashpad initialized successfully!" << std::endl;
+    std::cout << "Generating crash..." << std::endl;
 
-    return pBuf;
-#endif
+    generateExampleCallstackAndCrash();
+
+    return 0;
 }
 
 // Function to initialize Crashpad with BugSplat integration
-bool initializeCrashpad(std::string dbName, std::string appName, std::string appVersion) {
+bool initializeCrashpad(std::string dbName, std::string appName, std::string appVersion)
+{
     using namespace crashpad;
-    
-    // Get directory where the exe lives
+
     std::string exeDir = getExecutableDir();
 
     // Ensure that crashpad_handler is shipped with your application
@@ -95,12 +73,12 @@ bool initializeCrashpad(std::string dbName, std::string appName, std::string app
 
     // Metadata that will be posted to BugSplat
     std::map<std::string, std::string> annotations;
-    annotations["format"] = "minidump";              // Required: Crashpad setting to save crash as a minidump
-    annotations["database"] = dbName;                // Required: BugSplat database
-    annotations["product"] = appName;                // Required: BugSplat appName
-    annotations["version"] = appVersion;             // Required: BugSplat appVersion
-    annotations["key"] = "Sample key";               // Optional: BugSplat key field
-    annotations["user"] = "fred@bugsplat.com";       // Optional: BugSplat user email
+    annotations["format"] = "minidump";                                    // Required: Crashpad setting to save crash as a minidump
+    annotations["database"] = dbName;                                      // Required: BugSplat database
+    annotations["product"] = appName;                                      // Required: BugSplat appName
+    annotations["version"] = appVersion;                                   // Required: BugSplat appVersion
+    annotations["key"] = "Sample key";                                     // Optional: BugSplat key field
+    annotations["user"] = "fred@bugsplat.com";                             // Optional: BugSplat user email
     annotations["list_annotations"] = "Sample crash from dynamic library"; // Optional: BugSplat crash description
 
     // Disable crashpad rate limiting
@@ -110,21 +88,33 @@ bool initializeCrashpad(std::string dbName, std::string appName, std::string app
     // File paths of attachments to be uploaded with the minidump file at crash time
     std::vector<base::FilePath> attachments;
 #ifdef _WIN32
+    // On Windows, attachments are supported
     base::FilePath attachment(base::FilePath::StringType(exeDir.begin(), exeDir.end()) + L"/attachment.txt");
-#else
+    // Check if file exists before adding as attachment
+    if (std::filesystem::exists(attachment.value())) {
+        attachments.push_back(attachment);
+    }
+#elif defined(__linux__)
+    // On Linux, attachments are supported
     base::FilePath attachment(exeDir + "/attachment.txt");
+    // Check if file exists before adding as attachment
+    if (std::filesystem::exists(attachment.value())) {
+        attachments.push_back(attachment);
+    }
 #endif
-    attachments.push_back(attachment);
+    // Note: Attachments are not supported on macOS in some Crashpad configurations
 
     // Initialize Crashpad database
     std::unique_ptr<CrashReportDatabase> database = CrashReportDatabase::Initialize(reportsDir);
-    if (database == nullptr) {
+    if (database == nullptr)
+    {
         return false;
     }
 
     // Enable automated crash uploads
-    Settings* settings = database->GetSettings();
-    if (settings == nullptr) {
+    Settings *settings = database->GetSettings();
+    if (settings == nullptr)
+    {
         return false;
     }
     settings->SetUploadsEnabled(true);
@@ -138,117 +128,173 @@ bool initializeCrashpad(std::string dbName, std::string appName, std::string app
         url,
         annotations,
         arguments,
-        true,  // Restartable
-        true,  // Asynchronous
-        attachments  // Add attachment
+        true,       // Restartable
+        true,       // Asynchronous
+        attachments // Add attachment
     );
 
     return success;
 }
 
-// Create some dummy frames for a more interesting call stack
-void func2() {
-    std::cout << "In func2, loading library and about to crash...\n";
+// Struct to manage library handle and provide RAII cleanup
+struct LibraryHandle
+{
+#ifdef _WIN32
+    HMODULE handle;
+#else
+    void *handle;
+#endif
 
-    // Get the executable directory to find our library
+    LibraryHandle() : handle(nullptr) {}
+
+    ~LibraryHandle()
+    {
+        if (handle)
+        {
+#ifdef _WIN32
+            FreeLibrary(handle);
+#else
+            dlclose(handle);
+#endif
+        }
+    }
+
+    // Non-copyable
+    LibraryHandle(const LibraryHandle &) = delete;
+    LibraryHandle &operator=(const LibraryHandle &) = delete;
+};
+
+// Function to load crash library and return crash function pointer
+crash_func_t loadCrashFunction()
+{
     std::string exeDir = getExecutableDir();
-    
+
+    // Determine library path based on platform
 #ifdef _WIN32
     std::string libPath = exeDir + "/crash.dll";
-    // Load the DLL
-    HMODULE handle = LoadLibraryA(libPath.c_str());
-    if (!handle) {
-        std::cerr << "Failed to load library: " << GetLastError() << std::endl;
-        return;
-    }
-
-    // Get the crash function
-    typedef void (*crash_func_t)(void);
-    crash_func_t crash_func = (crash_func_t)GetProcAddress(handle, "crash");
-    if (!crash_func) {
-        std::cerr << "Failed to get crash function: " << GetLastError() << std::endl;
-        FreeLibrary(handle);
-        return;
-    }
 #elif defined(__APPLE__)
     std::string libPath = exeDir + "/libcrash.dylib";
-    // Load the shared library
-    void *handle = dlopen(libPath.c_str(), RTLD_LAZY);
-    if (!handle) {
-        std::cerr << "Failed to load library: " << dlerror() << std::endl;
-        return;
-    }
-
-    // Get the crash function
-    typedef void (*crash_func_t)(void);
-    dlerror(); // Clear any existing error
-    crash_func_t crash_func = (crash_func_t)dlsym(handle, "crash");
-    const char *dlsym_error = dlerror();
-    if (dlsym_error) {
-        std::cerr << "Failed to get crash function: " << dlsym_error << std::endl;
-        dlclose(handle);
-        return;
-    }
 #else // Linux
     std::string libPath = exeDir + "/libcrash.so.2";
-    // Load the shared library
-    void *handle = dlopen(libPath.c_str(), RTLD_LAZY);
-    if (!handle) {
-        std::cerr << "Failed to load library: " << dlerror() << std::endl;
-        return;
+#endif
+
+    // Load the library
+#ifdef _WIN32
+    HMODULE handle = LoadLibraryA(libPath.c_str());
+    if (!handle)
+    {
+        std::cerr << "Failed to load library: " << GetLastError() << std::endl;
+        return nullptr;
     }
 
     // Get the crash function
-    typedef void (*crash_func_t)(void);
+    crash_func_t crash_func = (crash_func_t)GetProcAddress(handle, "crash");
+    if (!crash_func)
+    {
+        std::cerr << "Failed to get crash function: " << GetLastError() << std::endl;
+        FreeLibrary(handle);
+        return nullptr;
+    }
+#else
+    void *handle = dlopen(libPath.c_str(), RTLD_LAZY);
+    if (!handle)
+    {
+        std::cerr << "Failed to load library: " << dlerror() << std::endl;
+        return nullptr;
+    }
+
+    // Get the crash function
     dlerror(); // Clear any existing error
     crash_func_t crash_func = (crash_func_t)dlsym(handle, "crash");
     const char *dlsym_error = dlerror();
-    if (dlsym_error) {
+    if (dlsym_error)
+    {
         std::cerr << "Failed to get crash function: " << dlsym_error << std::endl;
         dlclose(handle);
-        return;
+        return nullptr;
     }
 #endif
+
+    return crash_func;
+}
+
+// Create some dummy frames for a more interesting call stack
+void func2()
+{
+    std::cout << "In func2, loading library and about to crash...\n";
+
+    // Load crash function from library
+    crash_func_t crash_func = loadCrashFunction();
+    if (!crash_func)
+    {
+        std::cerr << "Failed to load crash function from library" << std::endl;
+        return;
+    }
 
     // Call the crash function
     crash_func();
 
     // We should never reach here
-#ifdef _WIN32
-    FreeLibrary(handle);
-#else
-    dlclose(handle);
-#endif
 }
 
-void func1() {
+void func1()
+{
     std::cout << "In func1, calling func2...\n";
     func2();
 }
 
-void func0() {
+void func0()
+{
     std::cout << "In func0, calling func1...\n";
     func1();
 }
 
-void generateExampleCallstackAndCrash() {
+void generateExampleCallstackAndCrash()
+{
     std::cout << "Starting call chain...\n";
     func0();
 }
 
-int main() {
-    // Initialize Crashpad
-    if (!initializeCrashpad(BUGSPLAT_DATABASE, BUGSPLAT_APP_NAME, BUGSPLAT_APP_VERSION)) {
-        std::cerr << "Failed to initialize Crashpad" << std::endl;
-        return 1;
+// Function to get the executable directory
+std::string getExecutableDir()
+{
+#ifdef _WIN32
+    char path[MAX_PATH];
+    GetModuleFileNameA(NULL, path, MAX_PATH);
+    std::string pathStr(path);
+    size_t lastBackslash = pathStr.find_last_of('\\');
+    if (lastBackslash != std::string::npos)
+    {
+        return pathStr.substr(0, lastBackslash);
+    }
+    return "";
+#elif defined(__APPLE__)
+    char path[PATH_MAX];
+    uint32_t size = sizeof(path);
+    if (_NSGetExecutablePath(path, &size) == 0)
+    {
+        std::string pathStr(path);
+        size_t lastSlash = pathStr.find_last_of('/');
+        if (lastSlash != std::string::npos)
+        {
+            return pathStr.substr(0, lastSlash);
+        }
+    }
+    return "";
+#else // Linux
+    char pBuf[FILENAME_MAX];
+    int len = sizeof(pBuf);
+    int bytes = MIN(readlink("/proc/self/exe", pBuf, len), len - 1);
+    if (bytes >= 0)
+    {
+        pBuf[bytes] = '\0';
     }
 
-    std::cout << "Hello, World!" << std::endl;
-    std::cout << "Crashpad initialized successfully!" << std::endl;
-    std::cout << "Generating crash..." << std::endl;
-    
-    // Generate an example callstack and crash
-    generateExampleCallstackAndCrash();
-    
-    return 0;
-} 
+    char *lastForwardSlash = strrchr(&pBuf[0], '/');
+    if (lastForwardSlash == NULL)
+        return "";
+    *lastForwardSlash = '\0';
+
+    return pBuf;
+#endif
+}

--- a/main.cpp
+++ b/main.cpp
@@ -40,9 +40,6 @@ int main()
 
     std::cout << "Hello, World!" << std::endl;
     std::cout << "Crashpad initialized successfully!" << std::endl;
-#ifdef _WIN32
-    std::cout << "WER integration enabled for enhanced crash detection!" << std::endl;
-#endif
     std::cout << "Generating crash..." << std::endl;
 
     generateExampleCallstackAndCrash();

--- a/main.h
+++ b/main.h
@@ -27,10 +27,5 @@ void func0();
 void func1();
 void func2();
 
-#ifdef _WIN32
-// Windows-specific WER callback functions
-bool registerWERCallbacks();
-void unregisterWERCallbacks();
-#endif
 
 #endif // MAIN_H 

--- a/main.h
+++ b/main.h
@@ -21,6 +21,7 @@ typedef void (*crash_func_t)(void);
 std::string getExecutableDir();
 bool initializeCrashpad(std::string dbName, std::string appName, std::string appVersion);
 crash_func_t loadCrashFunction();
+crash_func_t loadCrashFunction(const std::string& functionName);
 void generateExampleCallstackAndCrash();
 void func0();
 void func1();

--- a/main.h
+++ b/main.h
@@ -5,7 +5,7 @@
 
 // BugSplat Configuration
 // Replace BUGSPLAT_DATABASE with your database name from your BugSplat dashboard
-// #define BUGSPLAT_DATABASE "fred"
+#define BUGSPLAT_DATABASE "fred"
 #ifndef BUGSPLAT_DATABASE
 #error "BUGSPLAT_DATABASE must be defined. Please set it to your database name from your BugSplat dashboard."
 #endif
@@ -26,5 +26,11 @@ void generateExampleCallstackAndCrash();
 void func0();
 void func1();
 void func2();
+
+#ifdef _WIN32
+// Windows-specific WER callback functions
+bool registerWERCallbacks();
+void unregisterWERCallbacks();
+#endif
 
 #endif // MAIN_H 

--- a/main.h
+++ b/main.h
@@ -14,9 +14,13 @@
 #define BUGSPLAT_APP_NAME "MyCMakeCrasher"
 #define BUGSPLAT_APP_VERSION "1.0"
 
+// Function type for the crash function
+typedef void (*crash_func_t)(void);
+
 // Function declarations
 std::string getExecutableDir();
 bool initializeCrashpad(std::string dbName, std::string appName, std::string appVersion);
+crash_func_t loadCrashFunction();
 void generateExampleCallstackAndCrash();
 void func0();
 void func1();

--- a/wer.cpp
+++ b/wer.cpp
@@ -1,0 +1,96 @@
+// Copyright 2024 BugSplat Crashpad WER Integration
+// This module provides Windows Error Reporting (WER) callbacks to catch
+// exceptions that Crashpad might miss, particularly stack overflow errors.
+
+#ifdef _WIN32
+
+#include <Windows.h>
+// werapi.h must be after Windows.h
+#include <werapi.h>
+
+#include "third_party/crashpad/crashpad/handler/win/wer/crashpad_wer.h"
+
+extern "C" {
+
+// DLL entry point
+BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
+    switch (reason) {
+        case DLL_PROCESS_ATTACH:
+            // Disable thread library calls for performance
+            DisableThreadLibraryCalls(instance);
+            break;
+        case DLL_PROCESS_DETACH:
+            break;
+    }
+    return TRUE;
+}
+
+// Main WER callback function that handles out-of-process exceptions
+HRESULT OutOfProcessExceptionEventCallback(
+    PVOID pContext,
+    const PWER_RUNTIME_EXCEPTION_INFORMATION pExceptionInformation,
+    BOOL* pbOwnershipClaimed,
+    PWSTR pwszEventName,
+    PDWORD pchSize,
+    PDWORD pdwSignatureCount) {
+    
+    // List of exception types that WER should handle instead of Crashpad
+    // These are exceptions that Crashpad typically doesn't catch well
+    DWORD wanted_exceptions[] = {
+        0xC0000409,  // STATUS_STACK_BUFFER_OVERRUN (stack overflow/corruption)
+        0xC00000FD,  // STATUS_STACK_OVERFLOW (stack overflow)
+        0xC0000374,  // STATUS_HEAP_CORRUPTION (heap corruption)
+        0xC0000005,  // STATUS_ACCESS_VIOLATION (when in specific contexts)
+    };
+    
+    // Use Crashpad's WER integration to handle these exceptions
+    bool result = crashpad::wer::ExceptionEvent(
+        wanted_exceptions, 
+        sizeof(wanted_exceptions) / sizeof(DWORD), 
+        pContext,
+        pExceptionInformation);
+    
+    if (result) {
+        // We successfully handled the exception
+        *pbOwnershipClaimed = TRUE;
+        
+        // Return E_FAIL to indicate we've terminated the process
+        // This tells WER that we've handled it but the process should still terminate
+        return E_FAIL;
+    }
+    
+    // Could not handle the exception, let other WER handlers or default WER try
+    *pbOwnershipClaimed = FALSE;
+    return S_OK;
+}
+
+// WER signature callback - not used in our implementation
+HRESULT OutOfProcessExceptionEventSignatureCallback(
+    PVOID pContext,
+    const PWER_RUNTIME_EXCEPTION_INFORMATION pExceptionInformation,
+    DWORD dwIndex,
+    PWSTR pwszName,
+    PDWORD pchName,
+    PWSTR pwszValue,
+    PDWORD pchValue) {
+    
+    // This function should never be called in our implementation
+    return E_FAIL;
+}
+
+// WER debugger launch callback - not used in our implementation
+HRESULT OutOfProcessExceptionEventDebuggerLaunchCallback(
+    PVOID pContext,
+    const PWER_RUNTIME_EXCEPTION_INFORMATION pExceptionInformation,
+    PBOOL pbIsCustomDebugger,
+    PWSTR pwszDebuggerLaunch,
+    PDWORD pchDebuggerLaunch,
+    PBOOL pbIsDebuggerAutolaunch) {
+    
+    // This function should never be called in our implementation
+    return E_FAIL;
+}
+
+}  // extern "C"
+
+#endif  // _WIN32

--- a/wer.cpp
+++ b/wer.cpp
@@ -8,7 +8,7 @@
 // werapi.h must be after Windows.h
 #include <werapi.h>
 
-#include "third_party/crashpad/crashpad/handler/win/wer/crashpad_wer.h"
+#include "third_party/crashpad/handler/win/wer/crashpad_wer.h"
 
 extern "C" {
 

--- a/wer.def
+++ b/wer.def
@@ -1,0 +1,4 @@
+EXPORTS
+OutOfProcessExceptionEventCallback
+OutOfProcessExceptionEventSignatureCallback
+OutOfProcessExceptionEventDebuggerLaunchCallback

--- a/wer.h
+++ b/wer.h
@@ -1,0 +1,44 @@
+// Copyright 2024 BugSplat Crashpad WER Integration
+// Header file for Windows Error Reporting (WER) callback functionality
+
+#ifndef WER_H
+#define WER_H
+
+#ifdef _WIN32
+
+#include <Windows.h>
+#include <werapi.h>
+
+extern "C" {
+
+// WER callback functions that need to be exported from the DLL
+__declspec(dllexport) HRESULT OutOfProcessExceptionEventCallback(
+    PVOID pContext,
+    const PWER_RUNTIME_EXCEPTION_INFORMATION pExceptionInformation,
+    BOOL* pbOwnershipClaimed,
+    PWSTR pwszEventName,
+    PDWORD pchSize,
+    PDWORD pdwSignatureCount);
+
+__declspec(dllexport) HRESULT OutOfProcessExceptionEventSignatureCallback(
+    PVOID pContext,
+    const PWER_RUNTIME_EXCEPTION_INFORMATION pExceptionInformation,
+    DWORD dwIndex,
+    PWSTR pwszName,
+    PDWORD pchName,
+    PWSTR pwszValue,
+    PDWORD pchValue);
+
+__declspec(dllexport) HRESULT OutOfProcessExceptionEventDebuggerLaunchCallback(
+    PVOID pContext,
+    const PWER_RUNTIME_EXCEPTION_INFORMATION pExceptionInformation,
+    PBOOL pbIsCustomDebugger,
+    PWSTR pwszDebuggerLaunch,
+    PDWORD pchDebuggerLaunch,
+    PBOOL pbIsDebuggerAutolaunch);
+
+}  // extern "C"
+
+#endif  // _WIN32
+
+#endif  // WER_H


### PR DESCRIPTION
### Description

Adds an example that registers a callback with WER for handling crashes that Crashpad can't catch.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
