### PR TITLE
fix: remove HKCU creation for WER

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project demonstrates how to:
 
 1. Clone the depot_tools repository:
 
-```
+```bash
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ This project demonstrates how to:
 
 1. Clone the depot_tools repository:
 
-```bash
-# For Linux/macOS
+```
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ```
 
@@ -59,8 +58,9 @@ export PATH="$PATH:/path/to/depot_tools"
 ```
 
 ```powershell
-# For Windows - add to system environment variables or use:
+# For Windows - add to system environment variables or use the following powershell commands:
 $env:Path = "C:\path\to\depot_tools;$env:Path"
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH, "User")
 ```
 
 3. For Windows, you also need to run:

--- a/main.cpp
+++ b/main.cpp
@@ -71,8 +71,8 @@ void func2()
     // 3. STACK OVERFLOW
     // crash_func_t crash_func = loadCrashFunction("crashStackOverflow");
     
-    // 4. STACK BUFFER OVERWRITE (WER callback required for Windows see https://github.com/BugSplat-Git/bugsplat-crashpad/wiki/WER)
-    // crash_func_t crash_func = loadCrashFunction("crashStackOverwrite");
+    // 4. STACK BUFFER OVERRUN (WER callback required for Windows see https://github.com/BugSplat-Git/bugsplat-crashpad/wiki/WER)
+    // crash_func_t crash_func = loadCrashFunction("crashStackOverrun");
     
     if (!crash_func)
     {

--- a/main.cpp
+++ b/main.cpp
@@ -71,8 +71,8 @@ void func2()
     // 3. STACK OVERFLOW
     // crash_func_t crash_func = loadCrashFunction("crashStackOverflow");
     
-    // 4. STACK BUFFER OVERRUN (WER callback required for Windows see https://github.com/BugSplat-Git/bugsplat-crashpad/wiki/WER)
-    // crash_func_t crash_func = loadCrashFunction("crashStackOverrun");
+    // 4. STACK BUFFER OVERWRITE (WER callback required for Windows see https://github.com/BugSplat-Git/bugsplat-crashpad/wiki/WER)
+    // crash_func_t crash_func = loadCrashFunction("crashStackOverwrite");
     
     if (!crash_func)
     {
@@ -180,7 +180,26 @@ bool initializeCrashpad(std::string dbName, std::string appName, std::string app
     );
 
 #ifdef _WIN32
-    // Set up WER integration if Crashpad initialization was successful
+    // Set up Windows Error Reporting (WER) integration if Crashpad initialization was successful.
+    //
+    // REGISTRY REQUIREMENT:
+    // WER integration requires a specific registry configuration in:
+    //   HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules
+    //
+    // IMPORTANT: Creating registry values in HKEY_LOCAL_MACHINE requires elevated privileges.
+    //            This configuration should typically be created by your installer or setup process.
+    // 
+    // You must create a DWORD registry VALUE with:
+    //   Name: [full_path_to_crashpad_wer.dll]
+    //   Type: REG_DWORD
+    //   Data: 0 (value contents are ignored by WER)
+    //
+    // Example registry value:
+    //   Name: "C:\MyApp\bugsplat-crashpad\build\Debug\crashpad_wer.dll"
+    //   Type: REG_DWORD
+    //   Data: 0x00000000 (0)
+    //
+    // This configuration allows WER to delegate crash handling to your Crashpad handler.
     if (success) {
         setupWerIntegration(client, exeDir);
     }

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -23,7 +23,7 @@ echo "Configuring with Debug symbols for better crash reporting..."
 cmake .. -DCMAKE_BUILD_TYPE=Debug
 make
 
-echo "Build complete. Run the application with: ./Debug/MyCMakeCrasher"
+echo "Build complete. Run the application with: ./build/Debug/MyCMakeCrasher"
 
 # Return to root directory
 cd .. 

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -31,7 +31,7 @@ echo "Configuring with Debug symbols for better crash reporting..."
 cmake .. -DCMAKE_BUILD_TYPE=Debug
 make
 
-echo "Build complete. Run the application with: ./Debug/MyCMakeCrasher"
+echo "Build complete. Run the application with: ./build/Debug/MyCMakeCrasher"
 
 # Verify dSYM bundles were created in the Debug directory
 if [ ! -d "Debug/MyCMakeCrasher.dSYM" ] || [ ! -d "Debug/libcrash.dylib.dSYM" ]; then

--- a/scripts/build_windows_msvc.ps1
+++ b/scripts/build_windows_msvc.ps1
@@ -26,7 +26,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug
 # Build Debug configuration
 cmake --build . --config Debug
 
-Write-Host "Build complete. Run the application with: Debug\MyCMakeCrasher.exe"
+Write-Host "Build complete. Run the application with: .\build\Debug\MyCMakeCrasher.exe"
 
 # Return to root directory
 Set-Location -Path ".." 

--- a/scripts/upload_symbols.ps1
+++ b/scripts/upload_symbols.ps1
@@ -9,9 +9,15 @@ $envFile = Join-Path $rootDir ".env"
 if (Test-Path $envFile) {
     Write-Host "Loading environment from .env file..."
     Get-Content $envFile | ForEach-Object {
-        if ($_ -match '(.+)=(.+)') {
-            $key = $matches[1]
-            $value = $matches[2]
+        if ($_ -match '^\s*([^=\s]+)\s*=\s*(.*)$') {
+            $key = $matches[1].Trim()
+            $value = $matches[2].Trim()
+
+            # Remove surrounding quotes if present
+            if ($value -match '^"(.*)"$' -or $value -match "^'(.*)'$") {
+                $value = $matches[1]
+            }
+
             Set-Item -Path "Env:$key" -Value $value
         }
     }

--- a/windows.cpp
+++ b/windows.cpp
@@ -48,7 +48,7 @@ void setupWerIntegration(crashpad::CrashpadClient& client, const std::string& ex
       
     // Check registry key for WER integration
     bool registryExists = CheckRuntimeExceptionHelper(werDllPath);
-    if( !registryExists) {
+    if (!registryExists) {
         std::cout << "Crashpad WER registry key: " << werDllPath << " not found" << std::endl;
         std::cout << "Create this registry value in HKLM\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\RuntimeExceptionHelperModules" << std::endl;
         std::cout << "Continuing without WER integration" << std::endl;

--- a/windows.cpp
+++ b/windows.cpp
@@ -6,82 +6,66 @@
 #include <windows.h>
 #include <winreg.h>
 
-bool createWerRegistryKey(const std::string& dllPath) {
-    const char* registryPath = "SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\RuntimeExceptionHandlerModules";
-    HKEY hKey;
-    
-    // Open/create the registry key
-    LONG result = RegCreateKeyExA(
-        HKEY_CURRENT_USER,
-        registryPath,
-        0,
-        NULL,
-        REG_OPTION_NON_VOLATILE,
-        KEY_WRITE,
-        NULL,
-        &hKey,
-        NULL
-    );
+BOOL DoesRegistryValueExist(HKEY hRootKey, LPCWSTR keyPath, LPCWSTR valueName)
+{
+    HKEY hKey = NULL;
+    LSTATUS result = RegOpenKeyExW(hRootKey, keyPath, 0, KEY_READ, &hKey);
     
     if (result != ERROR_SUCCESS) {
-        std::cerr << "Failed to open/create WER registry key. Error: " << result << std::endl;
-        return false;
+        return FALSE;  // Key doesn't exist
     }
     
-    // Set the DLL path as a DWORD value with data 0x0
-    DWORD value = 0x0;
-    result = RegSetValueExA(
-        hKey,
-        dllPath.c_str(),  // Value name is the full DLL path
-        0,
-        REG_DWORD,
-        reinterpret_cast<const BYTE*>(&value),
-        sizeof(DWORD)
-    );
-    
+    // Check if the specific value exists
+    result = RegQueryValueExW(hKey, valueName, NULL, NULL, NULL, NULL);
     RegCloseKey(hKey);
     
-    if (result != ERROR_SUCCESS) {
-        std::cerr << "Failed to set WER registry value. Error: " << result << std::endl;
-        return false;
-    }
-    
-    std::cout << "Successfully created WER registry key for: " << dllPath << std::endl;
-    return true;
+    return (result == ERROR_SUCCESS);
 }
 
-void setupWerIntegration(crashpad::CrashpadClient& client, const std::string& exeDir) {
-    std::string werDllPath = exeDir + "\\crashpad_wer.dll";
-    std::cout << "Looking for Crashpad WER DLL at: " << werDllPath << std::endl;
+// Check for RuntimeExceptionHelperModules key
+BOOL CheckRuntimeExceptionHelper(const std::string& dllPath)
+{
+    const LPCWSTR keyPath = L"SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\RuntimeExceptionHelperModules";
+        
+    // Create the value name we're looking for
+    std::wstring wideDllPath(dllPath.begin(), dllPath.end());
+    WCHAR valueName[2048];
+    swprintf_s(valueName, 2048, wideDllPath.c_str());
     
+    // Check if our specific value exists
+    BOOL exists = DoesRegistryValueExist(HKEY_LOCAL_MACHINE, keyPath, valueName);
+    
+    return exists;
+}
+
+
+void setupWerIntegration(crashpad::CrashpadClient& client, const std::string& exeDir) {
+    std::string werDllPath = exeDir + "\\crashpad_wer.dll";    
     if (!std::filesystem::exists(werDllPath)) {
-        std::cout << "Crashpad WER DLL not found - continuing without WER integration" << std::endl;
+        std::cout << "Crashpad WER DLL not found at: " << werDllPath << " - continuing without WER integration" << std::endl;
         return;
     }
-    
-    std::cout << "Crashpad WER DLL found, setting up WER integration..." << std::endl;
-    
-    // Create registry key for WER integration
-    bool registryCreated = createWerRegistryKey(werDllPath);
+      
+    // Check registry key for WER integration
+    bool registryExists = CheckRuntimeExceptionHelper(werDllPath);
+    if( !registryExists) {
+        std::cout << "Crashpad WER registry key: " << werDllPath << " not found" << std::endl;
+        std::cout << "Create this registry value in HKLM\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\RuntimeExceptionHelperModules" << std::endl;
+        std::cout << "Continuing without WER integration" << std::endl;
+        return; 
+    }
     
     // Register WER module with Crashpad
     std::wstring werDllPathW(werDllPath.begin(), werDllPath.end());
     bool moduleRegistered = client.RegisterWerModule(werDllPathW);
     
     // Report results
-    if (registryCreated && moduleRegistered) {
-        std::cout << "Successfully set up WER integration: " << werDllPath << std::endl;
+    if (!moduleRegistered) {
+        std::cerr << "Warning: Failed to register WER module with Crashpad - continuing without WER integration" << std::endl;
         return;
     }
     
-    // Handle partial or complete failure
-    if (!registryCreated) {
-        std::cerr << "Warning: Failed to create WER registry key" << std::endl;
-    }
-    if (!moduleRegistered) {
-        std::cerr << "Warning: Failed to register WER module with Crashpad" << std::endl;
-    }
-    std::cerr << "WER integration may not work properly" << std::endl;
+    std::cout << "Successfully set up WER integration: " << werDllPath << std::endl;
 }
 
 #endif // _WIN32

--- a/windows.h
+++ b/windows.h
@@ -8,14 +8,6 @@
 
 // Windows-specific WER (Windows Error Reporting) integration functions
 
-/**
- * Creates a Windows registry key for WER integration.
- * Registers the crashpad_wer.dll path in HKEY_CURRENT_USER for Windows Error Reporting.
- * 
- * @param dllPath Full absolute path to crashpad_wer.dll
- * @return true if registry key was created successfully, false otherwise
- */
-bool createWerRegistryKey(const std::string& dllPath);
 
 /**
  * Sets up complete WER integration for Crashpad.


### PR DESCRIPTION
### Description

- Change handling of registry key.  This must now be created outside of the sample program code.
- Improve error messages
- Script changes to handle quotes and spaces in the .env file

Fixes # (issue)

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
